### PR TITLE
Error in query parameter for block number flashbot api #4

### DIFF
--- a/components/Bundles.tsx
+++ b/components/Bundles.tsx
@@ -30,7 +30,7 @@ export default function Bundles({ bundles }) {
       setBundleAndOpen(local);
     } else {
       try {
-        const blocks = await getBlocks({ blockNumber })
+        const blocks = await getBlocks({ block_number: blockNumber })
         if (blocks) {
           setBundleAndOpen(blocks[0]);
         }


### PR DESCRIPTION
I can not test properly the results because the fetch return CORS errors, and when put fetch in "mode: no-cors" does return nothing.

With the query parameter with the correct name, in the flashbots api it filters properly.

#4 