### PR TITLE
Remove query param when closing instead of going back

### DIFF
--- a/components/BundleModal.tsx
+++ b/components/BundleModal.tsx
@@ -10,7 +10,9 @@ export default function BundleModal({ open, bundle, setOpen }) {
   const close = () => {
     setOpen(false);
     if (bundle) {
-      router.back();
+      const { pathname, query } = router;
+      delete query.block;
+      router.push({ pathname, query });
     }
   };
 


### PR DESCRIPTION
The app was crashing for me when inspecting bundles after landing on a permalink to a specific block. After this I can no longer reproduce.