### PR TITLE
Use CSS to shorten the transaction hash so that it can be CTRL+F'd

### DIFF
--- a/components/BundleModal.tsx
+++ b/components/BundleModal.tsx
@@ -257,7 +257,7 @@ function BundleTransaction({ transaction, index }) {
       <td className="block-number px-6 py-4 whitespace-nowrap text-center">
         <a className="flex text-sm justify-center hover:underline" target="_blank" rel="noreferrer" href={`https://etherscan.io/tx/${ transaction.transaction_hash }`}>
           { ExternalLinkIcon }
-          <span className="ml-3"> { transaction?.transaction_hash.slice(0, 10) }... </span>
+          <TransactionHash hash={transaction?.transaction_hash}/>
         </a>
       </td>
       <td className="px-6 py-4 whitespace-nowrap text-center">
@@ -311,6 +311,10 @@ function BundleTransaction({ transaction, index }) {
       </td>
     </tr>
   </Fragment>;
+}
+
+const TransactionHash = ({hash}) => {
+  return <span className="ml-3" style={{ whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis", maxWidth: "100px" }}>{hash}</span>
 }
 
 const Error = ({ blockNumber }) => <div>

--- a/components/BundleModal.tsx
+++ b/components/BundleModal.tsx
@@ -257,7 +257,7 @@ function BundleTransaction({ transaction, index }) {
       <td className="block-number px-6 py-4 whitespace-nowrap text-center">
         <a className="flex text-sm justify-center hover:underline" target="_blank" rel="noreferrer" href={`https://etherscan.io/tx/${ transaction.transaction_hash }`}>
           { ExternalLinkIcon }
-          <TransactionHash hash={transaction?.transaction_hash}/>
+          <TransactionHash hash={transaction?.transaction_hash} />
         </a>
       </td>
       <td className="px-6 py-4 whitespace-nowrap text-center">


### PR DESCRIPTION
When looking at larger bundles and expecting a certain TX to be there, I've tried to just CTRL+F for the transaction hash when the modal appears.

This doesn't work as it gets shortended in JS. With this change it gets shortened by CSS (`text-overflow` [is supported by all browsers for years](https://caniuse.com/text-overflow)) and can then be searched. This is a small but user-friendly change.

I've tested and it works fine on desktop and mobile with Firefox.